### PR TITLE
fix(instance): add getter to SimpleInstance value

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `SimpleInstance` is a utility for when you need an instance with some state 
 let i = 0;
 const cluster: Cluster<SimpleInstance<number>> = new Cluster(3, () => new SimpleInstance(++i));
 cluster.submit((instance) => {
-  console.log(`Running task on instance ${instance}`)
+  console.log(`Running task on instance ${instance.getValue()}`)
   // do something with the instance
 })
 ```

--- a/src/main/instance/SimpleInstance.ts
+++ b/src/main/instance/SimpleInstance.ts
@@ -10,4 +10,8 @@ export class SimpleInstance<T> implements Instance {
     shutdown(): void | Promise<void> {
         // Nothing to do on shutdown
     }
+
+    public getValue(): T {
+        return this.value;
+    }
 }

--- a/src/test/instance/SimpleInstance.test.ts
+++ b/src/test/instance/SimpleInstance.test.ts
@@ -5,4 +5,10 @@ describe('SimpleInstance', () => {
         const instance = new SimpleInstance(1);
         expect(instance.shutdown()).toBe(undefined);
     });
+
+    it('gets value', () => {
+        const random = Math.floor(Math.random() * 1000);
+        const instance = new SimpleInstance(random);
+        expect(instance.getValue()).toEqual(random);
+    });
 });


### PR DESCRIPTION
Adds a getter to the SimpleInstance to retrieve its value. This means that the inner value can be used as a context for the task that the instance will be running.