### PR TITLE
feat: allow tasks to return value

### DIFF
--- a/src/main/cluster/Cluster.ts
+++ b/src/main/cluster/Cluster.ts
@@ -57,10 +57,10 @@ export class Cluster<T extends Instance> {
      * @param backoffOptions the exponential-backoff options to retry acquiring a free instance. If not provided, the cluster will use its default ones.
      * @returns a promise that completes when the task is done.
      */
-    public async submit(
-        task: (i: T) => Promise<void>,
+    public async submit<R>(
+        task: (i: T) => Promise<R>,
         backoffOptions: ClusterBackoffOptions = this.defaultBackoffOptions
-    ): Promise<void> {
+    ): Promise<R> {
         return this.acquire(backoffOptions).then((instance) => task(instance).finally(() => this.release(instance)));
     }
 

--- a/src/test/cluster/Cluster.test.ts
+++ b/src/test/cluster/Cluster.test.ts
@@ -152,4 +152,13 @@ describe('Cluster', () => {
         expect(cluster.shutdownNow()).resolves.toBeTruthy();
         expect(cluster.shutdownNow()).resolves.toBeFalsy();
     });
+
+    it('returns task value when it completes', async () => {
+        const cluster = new Cluster<Instance>(1, () => new EmptyInstance());
+        const random = Math.floor(Math.random() * 1000);
+
+        const result = await cluster.submit(() => Promise.resolve(random));
+
+        expect(result).toEqual(random);
+    });
 });


### PR DESCRIPTION
Allows tasks submitted to the cluster to return a value. The `submit()` method will return whatever value the task returns.