### PR TITLE
feat(cluster): allow instances to be created eagerly

### DIFF
--- a/src/main/cluster/BasicCluster.ts
+++ b/src/main/cluster/BasicCluster.ts
@@ -1,4 +1,4 @@
-import { Cluster, ClusterBackoffOptions } from './Cluster';
+import { Cluster, ClusterBackoffOptions, ClusterOptions } from './Cluster';
 import { EmptyInstance } from '../instance/EmptyInstance';
 
 /**
@@ -13,7 +13,7 @@ export class BasicCluster extends Cluster<EmptyInstance> {
      * @param clusterSize how many instances the cluster can contain (and, conversely, how many tasks it can run in parallel)
      * @param defaultBackoffOptions the exponential-backoff options this cluster will use by default for retrying the acquisition of a free instance and for performing a graceful shutdown.
      */
-    public constructor(clusterSize: number, defaultBackoffOptions?: ClusterBackoffOptions) {
-        super(clusterSize, () => new EmptyInstance(), defaultBackoffOptions);
+    public constructor(clusterSize: number, clusterOptions?: ClusterOptions) {
+        super(clusterSize, () => new EmptyInstance(), clusterOptions);
     }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-export { Cluster } from './cluster/Cluster';
+export { Cluster, ClusterOptions, ClusterBackoffOptions } from './cluster/Cluster';
 export { BasicCluster } from './cluster/BasicCluster';
 export { Instance } from './instance/Instance';
 export { EmptyInstance } from './instance/EmptyInstance';

--- a/src/test/cluster/BasicCluster.test.ts
+++ b/src/test/cluster/BasicCluster.test.ts
@@ -15,8 +15,10 @@ describe('BasicCluster', () => {
 
     it('overrides default backoff options', async () => {
         const cluster = new BasicCluster(3, {
-            startingDelay: 10000,
-            maxDelay: 10000,
+            defaultBackoffOptions: {
+                startingDelay: 10000,
+                maxDelay: 10000,
+            },
         });
 
         const done: number[] = [];


### PR DESCRIPTION
Adds option to cluster to create instances eagerly. When that option is set, the constructor will begin creating instances straight away. The constructor will potentially return before instances creation is finished

BREAKING CHANGE: constructor arguments changed to accept an object of `ClusterOptions`. This will make it easier to add new options in the future without changing the constructor signature