### PR TITLE
feat(instance): move release and lock responsability to instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "basic-cluster",
             "version": "0.4.0",
+            "license": "MIT",
             "dependencies": {
                 "exponential-backoff": "^3.1.1"
             },

--- a/src/main/instance/BasicInstance.ts
+++ b/src/main/instance/BasicInstance.ts
@@ -1,0 +1,28 @@
+import { Instance } from './Instance';
+
+export abstract class BasicInstance implements Instance {
+    protected runningTask: boolean;
+
+    abstract shutdown(): void | Promise<void>;
+
+    constructor() {
+        this.runningTask = false;
+    }
+
+    isFree(): boolean {
+        return !this.runningTask;
+    }
+
+    async submit<R>(task: (i: this) => Promise<R>): Promise<R> {
+        await this.lock();
+        return task(this).finally(() => this.release());
+    }
+
+    lock(): void | Promise<void> {
+        this.runningTask = true;
+    }
+
+    release(): void | Promise<void> {
+        this.runningTask = false;
+    }
+}

--- a/src/main/instance/EmptyInstance.ts
+++ b/src/main/instance/EmptyInstance.ts
@@ -1,9 +1,10 @@
+import { BasicInstance } from './BasicInstance';
 import { Instance } from './Instance';
 
 /**
  * An instance with no inner objects to run tasks that don't require an execution context.
  */
-export class EmptyInstance implements Instance {
+export class EmptyInstance extends BasicInstance {
     /**
      * @inheritdoc
      */

--- a/src/main/instance/Instance.ts
+++ b/src/main/instance/Instance.ts
@@ -6,4 +6,8 @@ export interface Instance {
      * Shuts down the instance.
      */
     shutdown(): void | Promise<void>;
+
+    submit<R>(task: (i: Instance) => Promise<R>): Promise<R>;
+
+    isFree(): boolean;
 }

--- a/src/main/instance/SimpleInstance.ts
+++ b/src/main/instance/SimpleInstance.ts
@@ -1,9 +1,10 @@
+import { BasicInstance } from './BasicInstance';
 import { Instance } from './Instance';
 
 /**
  * An instance with some context but which does not require any special shutdown action.
  */
-export class SimpleInstance<T> implements Instance {
+export class SimpleInstance<T> extends BasicInstance {
     /**
      * The context of the instance.
      */
@@ -15,6 +16,7 @@ export class SimpleInstance<T> implements Instance {
      * @param value the context of the instance.
      */
     constructor(value: T) {
+        super();
         this.value = value;
     }
 

--- a/src/test/cluster/Cluster.test.ts
+++ b/src/test/cluster/Cluster.test.ts
@@ -1,4 +1,5 @@
 import { Cluster, ClusterOptions } from '../../main/cluster/Cluster';
+import { BasicInstance } from '../../main/instance/BasicInstance';
 import { EmptyInstance } from '../../main/instance/EmptyInstance';
 import { Instance } from '../../main/instance/Instance';
 
@@ -125,11 +126,15 @@ describe('Cluster', () => {
     });
 
     it('does not accept more tasks after shutdown', async () => {
-        const cluster = new Cluster<Instance>(1, () => ({
-            shutdown() {
-                return new Promise((_) => setTimeout(_, 1000));
-            },
-        }));
+        const cluster = new Cluster<Instance>(
+            1,
+            () =>
+                new (class extends BasicInstance {
+                    shutdown(): void | Promise<void> {
+                        return new Promise((_) => setTimeout(_, 1000));
+                    }
+                })()
+        );
 
         cluster.submit(async () => {
             await new Promise((_) => setTimeout(_, 1000));


### PR DESCRIPTION
Moves the responsability to lock and release to the instances themselves. This allows instances to be independent in managing their state and allows for more complex instances

BREAKING CHANGE: the Instance interface has been changed. If you were implementing it directly, you can keep the previous behavior by extending `BasicInstance`